### PR TITLE
Add smooth scrolling and removed previous indicator bar from event tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+docs
+node_modules

--- a/client/src/components/EventCard/EventCard.css
+++ b/client/src/components/EventCard/EventCard.css
@@ -2,14 +2,14 @@
     cursor: pointer;
     /* font-size: 8.2px !important; */
     position: relative;
-    width: 24rem !important;
-    height: 7.5rem ;
+    width: 29rem !important;
+    height: 9rem ;
     z-index: 1 ;
     clip-path: polygon(0 0, 60% 0, 90% 40%, 98% 39%, 100% 46%, 100% 100%, 0 100%);
 }
 
 .EventCardMain {
-    width: 24rem;
+    width: 29rem;
     position: relative;
 }
 

--- a/client/src/components/EventTabLabels/EventTabLabels.css
+++ b/client/src/components/EventTabLabels/EventTabLabels.css
@@ -1,3 +1,20 @@
+.outerDivTab {
+    position: relative;
+    transform: translateX(0);
+    transition: all 0.3s ease-out;
+    margin: 0.5rem 0;
+    width: 100%;
+}
+
+.outerDivTab:hover {
+    transform: translateX(-8px);
+}
+
+.outerDivTab.active {
+    transform: translateX(-12px);
+    margin: 1rem 0;
+}
+
 .outerDivTab .tabLabels-wrapper {
     cursor: pointer;
     position: relative;
@@ -5,6 +22,7 @@
     height: 6rem;
     border-radius: 0.5rem;
     clip-path: polygon(0 0, 60% 0, 90% 40%, 98% 39%, 100% 46%, 100% 100%, 0 100%);
+    transition: all 0.3s ease-out;
 }
 
 .outerDivTab .tabLabels-wrapper .section1 {
@@ -15,6 +33,7 @@
     width: 100%;
     height: 100%;
     border-radius: 0.5rem;
+    transition: all 0.3s ease-out;
 }
 
 .outerDivTab .tabLabels-wrapper .section1 .title {
@@ -48,6 +67,15 @@
     position: absolute;
     top: -13%;
     right: 4%;
+    transition: transform 0.3s ease-out;
+}
+
+.outerDivTab:hover img {
+    transform: rotate(10deg) scale(1.05);
+}
+
+.outerDivTab.active img {
+    transform: rotate(15deg) scale(1.1);
     z-index: 5 !important;
 }
 

--- a/client/src/components/EventTabLabels/EventTabLabels.jsx
+++ b/client/src/components/EventTabLabels/EventTabLabels.jsx
@@ -10,16 +10,27 @@ export default function EventTabLabels(
         onClick
     }
 ) {
-    // const outerDivRef = useRef()
-    // useEffect(() => {
-    //     if (isClicked && outerDivRef.current) {
-    //         outerDivRef.current.scrollIntoView({ behaviour: "smooth", block: "end" })
-    //     }
-    // }, [isClicked])
+    const tabRef = useRef();
+
+    useEffect(() => {
+        if (isClicked && tabRef.current) {
+            tabRef.current.scrollIntoView({ 
+                behavior: 'smooth',
+                block: 'nearest'
+            });
+        }
+    }, [isClicked]);
 
     return (
-        <div onClick={onClick} className="outerDivTab">
-            <img src={`/assets/thumbnail/${imageVariant}.png`} />
+        <div 
+            ref={tabRef}
+            onClick={onClick} 
+            className={`outerDivTab ${isClicked ? 'active' : ''}`}
+        >
+            <img 
+                src={`/assets/thumbnail/${imageVariant}.png`} 
+                className="tab-image"
+            />
             <div className="tabLabels-wrapper">
                 <div
                     style={isClicked ? { "background": "var(--gradient2)" } : { "background": "linear-gradient(135deg, rgba(239, 231, 231, 0.18), rgba(211, 204, 204, 0.185))" }}
@@ -31,7 +42,6 @@ export default function EventTabLabels(
                 </div>
             </div>
         </div>
-
     )
 
 

--- a/client/src/screens/Events/Events.css
+++ b/client/src/screens/Events/Events.css
@@ -8,40 +8,61 @@
 .eventsBox {
     display: flex;
     width: 100%;
+    gap: 2rem;
+    padding: 0 2rem;
 }
 
 .eventsBox .eventCard {
-    flex: 1;
+    flex: 1.2;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: start;
+    min-width: 0; /* Prevent flex item from overflowing */
 }
 
 .eventsBox .eventLabels {
-    flex: 1;
+    flex: 0.8;
     display: flex;
-    align-items: center;
-    gap: 3rem;
-    justify-content: end
+    align-items: flex-start;
+    gap: 1.5rem;
+    justify-content: flex-end;
+    padding-top: 2rem;
 }
 
 .eventsBox .eventLabels .eventLabelsBoxes {
     display: flex;
     flex-direction: column;
-    /* height: 85%; */
     justify-content: start;
     align-items: center;
-    /* overflow: scroll; */
-    gap: 1rem;
+    gap: 0.5rem;
+    padding-right: 1rem;
+    padding-left: 1rem;
+    width: 100%;
+    max-height: 80vh;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+}
+
+.eventsBox .eventLabels .eventLabelsBoxes::-webkit-scrollbar {
+    width: 5px;
+}
+
+.eventsBox .eventLabels .eventLabelsBoxes::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.eventsBox .eventLabels .eventLabelsBoxes::-webkit-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.3);
+    border-radius: 100px;
+}
+
+.eventsBox .eventLabels .eventLabelsBoxes::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(255, 255, 255, 0.5);
 }
 
 .eventsBox .eventLabels .eventLabelsSlider {
-    /* height: 85%; */
-    /* width: 15%; */
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
+    display: none;
     align-items: center;
     gap: 1rem
 }

--- a/client/src/screens/Events/Events.jsx
+++ b/client/src/screens/Events/Events.jsx
@@ -67,19 +67,19 @@ const Events = () => {
 
             <div className="eventsBox inner-content">
                 <MobileEvents />
-                <div className="eventCard" style={{transform: `scale(${scaling})`, paddingTop: "2rem", transformOrigin: "left"}}>
-                    <EventCard {...EventsData[tabDelta + clickedImage - 1]} />
+                <div className="eventCard">
+                    <EventCard {...EventsData[clickedImage - 1]} />
                 </div>
                 <div ref={containerRef} className="eventLabels">
                     <div
                         className="eventLabelsBoxes"
-                        style={
-                            {
-                                // height: `${tabNum*16}px`
-                            }
-                        }
+                        style={{
+                            scrollBehavior: 'smooth',
+                            overflowY: 'auto',
+                            maxHeight: `${height}px`
+                        }}
                     >
-                        {EventsData.slice(0 + tabDelta, tabNum + tabDelta).map((e, i) => (
+                        {EventsData.map((e, i) => (
                             <EventTabLabels
                                 key={i}
                                 title={e.title}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "codeiiest-gdsc",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Fixes #6 
 Implemented smooth scrolling navigation
 Shows all events in a scrollable list
 Custom-styled minimal scrollbar
 Automatic scrolling to selected event

<img width="2865" height="1432" alt="image" src="https://github.com/user-attachments/assets/0a374a4d-819f-4a59-a19d-c26d8d0d4356" />

But one issue in my code is that event card size is now smaller then previous.